### PR TITLE
Added onError to plugin config for custom response formats

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,7 +119,7 @@ exports.register = (server, options, next) => {
                     }
 
                     if (result === RbacCore.UNDETERMINED) {
-                        return options.onError(request, reply, Boom.create(options.responseCode.onUndetermined, 'No permissions to access this resource'));
+                        return options.onError(request, reply, Boom.create(options.responseCode.onUndetermined, 'Could not evaluate access rights to resource'));
                     }
 
                     reply.continue();

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,7 @@ internals.retrievePolicy = (config, request, callback) => {
  * Hapi register function
  **/
 schemas.register_options = Joi.object({
+    onError: Joi.func().optional(),
     responseCode: Joi.object({
         onDeny: Joi.number().optional(),
         onUndetermined: Joi.number().optional()
@@ -58,6 +59,9 @@ schemas.register_options = Joi.object({
 });
 
 defaults.options = {
+    onError: function(request, reply, err) {
+        reply(Boom.wrap(err, 401));
+    },
     responseCode: {
         onDeny: 401,
         onUndetermined: 401
@@ -94,7 +98,7 @@ exports.register = (server, options, next) => {
             return internals.retrievePolicy(config, request, (err, policy) => {
 
                 if (err) {
-                    return reply(err);
+                    return options.onError(request, reply, err);
                 }
 
                 if (!policy || policy === CONFIG_NONE) {
@@ -107,15 +111,15 @@ exports.register = (server, options, next) => {
                 RbacCore.evaluatePolicy(policy, wrappedDataRetriever, (err, result) => {
 
                     if (err) {
-                        return reply(err);
+                        return options.onError(request, reply, err);
                     }
 
                     if (result === RbacCore.DENY) {
-                        return reply(Boom.create(options.responseCode.onDeny, 'No permissions to access this resource'));
+                        return options.onError(request, reply, Boom.create(options.responseCode.onDeny, 'No permissions to access this resource'));
                     }
 
                     if (result === RbacCore.UNDETERMINED) {
-                        return reply(Boom.create(options.responseCode.onUndetermined, 'Could not evaluate access rights to resource'));
+                        return options.onError(request, reply, Boom.create(options.responseCode.onUndetermined, 'No permissions to access this resource'));
                     }
 
                     reply.continue();


### PR DESCRIPTION
Hi, I'm using a custom response format in one of my projects and I thought I'd add that feature as a configurable option.
Boom is nice, but sometimes we need to adhere by certain standards for the response format like the [json api](http://jsonapi.org/) standard... this pull request makes it possible.